### PR TITLE
Changes to toStrig method in Coordinates Class . StringBuilder to be …

### DIFF
--- a/src/com/thoughtworks/rover/universe/Coordinates.java
+++ b/src/com/thoughtworks/rover/universe/Coordinates.java
@@ -16,7 +16,7 @@ public class Coordinates {
 
     @Override
     public String toString() {
-        StringBuffer coordinateOutput = new StringBuffer();
+        StringBuilder coordinateOutput = new StringBuilder();
         coordinateOutput.append(xCoordinate);
         coordinateOutput.append(" ");
         coordinateOutput.append(yCoordinate);


### PR DESCRIPTION
…used in toString Method instead of StringBuffer as it is not shared in more than one threads. StringBuilder gives relatively high performance.
